### PR TITLE
fix(security): abort OAuth WebView load on SSL certificate errors (CWE-295)

### DIFF
--- a/src/com/neovisionaries/android/twitter/TwitterOAuthView.java
+++ b/src/com/neovisionaries/android/twitter/TwitterOAuthView.java
@@ -892,7 +892,12 @@ public class TwitterOAuthView extends WebView
             @Override
             public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error)
             {
-                handler.proceed();
+                // CWE-295: do NOT proceed on invalid certificates. This view
+                // hosts the Twitter OAuth authorization flow; silently
+                // trusting any cert lets a network attacker MITM the OAuth
+                // handshake and steal the request_token / verifier (and
+                // therefore the user's account access). Abort the request.
+                handler.cancel();
             }
 
 


### PR DESCRIPTION
## Security fix - issue #7 (CWE-295)

Resolves #7

### Root cause

`LocalWebViewClient` (the inner `WebViewClient` used to host the
Twitter OAuth flow) overrides `onReceivedSslError` and unconditionally
calls `handler.proceed()`:

```java
@Override
public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error)
{
    handler.proceed();
}
```

That tells the WebView to trust **any** certificate the server
presents - expired, self-signed, hostname-mismatched, or attacker-
issued. Because this view hosts the Twitter OAuth authorization
endpoint, a network attacker (open Wi-Fi, hostile ISP, captive
portal) can MITM the TLS connection, observe the OAuth
`request_token` and `oauth_verifier`, and complete the token exchange
themselves - giving them full access to the victim's Twitter account
under the calling app's API key.

### What this PR changes

One file, `src/com/neovisionaries/android/twitter/TwitterOAuthView.java`:

- `LocalWebViewClient.onReceivedSslError` now calls `handler.cancel()`
  instead of `handler.proceed()`, so the authorization request is
  aborted whenever the certificate fails the platform's validation.

### Scope

Only the SSL error handler is touched. The rest of `LocalWebViewClient`
(`onReceivedError`, `onPageStarted`, `shouldOverrideUrlLoading`, etc.)
and all OAuth flow logic is unchanged.
